### PR TITLE
fix build for ghidra 11.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,8 @@ repositories{
 }
 
 dependencies{
-    compileClasspath 'io.kaitai:kaitai-struct-runtime:0.9@jar'
+    // https://mvnrepository.com/artifact/io.kaitai/kaitai-struct-runtime
+    implementation 'io.kaitai:kaitai-struct-runtime:0.9'
 }
 
 task copyLibs(type: Copy, ) {
@@ -46,4 +47,6 @@ task copyLibs(type: Copy, ) {
     include "kaitai*"
 }
 
-buildExtension.dependsOn copyLibs
+// buildExtension.dependsOn copyLibs
+
+buildExtension


### PR DESCRIPTION
Using `gradle 8+` results in the following build error due to the use of `compileClasspath`.

```sh
FAILURE: Build failed with an exception.

* Where:
Build file 'C:\Users\username\Documents\xcoff-ghidra\build.gradle' line: 40

* What went wrong:
A problem occurred evaluating root project 'xcoff-ghidra'.
> Dependencies can not be declared against the `compileClasspath` configuration.
```

This PR fixes the build using `gradle 8+` to permit building for Ghidra 11.0.1.
